### PR TITLE
Traiter les erreurs dans les composants

### DIFF
--- a/trading-charts/src/bindings/error.rs
+++ b/trading-charts/src/bindings/error.rs
@@ -1,3 +1,4 @@
+use crate::console;
 use js_sys::Reflect;
 use serde_wasm_bindgen::Error as SerdeError;
 use wasm_bindgen::JsValue;
@@ -28,6 +29,10 @@ impl JsError {
     #[allow(dead_code)]
     pub(crate) fn message(&self) -> &str {
         &self.message
+    }
+
+    pub(crate) fn log(&self) {
+        console::error(&self.message);
     }
 }
 

--- a/trading-charts/src/console.rs
+++ b/trading-charts/src/console.rs
@@ -1,0 +1,26 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen]
+extern "C" {
+    #[allow(dead_code)]
+    #[wasm_bindgen(js_namespace = console)]
+    pub(crate) fn log(s: &str);
+
+    #[allow(dead_code)]
+    #[wasm_bindgen(js_namespace = console)]
+    pub(crate) fn error(s: &str);
+}
+
+#[allow(unused_macros)]
+macro_rules! console_log {
+    // Note that this is using the `log` function imported above during
+    // `bare_bones`
+    ($($t:tt)*) => ($crate::console::log(&format_args!($($t)*).to_string()))
+}
+
+#[allow(unused_macros)]
+macro_rules! console_error {
+    // Note that this is using the `log` function imported above during
+    // `bare_bones`
+    ($($t:tt)*) => ($crate::console::error(&format_args!($($t)*).to_string()))
+}

--- a/trading-charts/src/lib.rs
+++ b/trading-charts/src/lib.rs
@@ -1,5 +1,6 @@
 mod bindings;
 mod chart;
+mod console;
 
 pub mod data;
 pub mod series;

--- a/trading-charts/src/series/candlesticks/component.rs
+++ b/trading-charts/src/series/candlesticks/component.rs
@@ -30,7 +30,12 @@ pub fn CandleStickSeries(
                 series.set_options(options.get());
             }
 
-            chart.add_series(&mut series).unwrap();
+            if let Err(err) = chart.add_series(&mut series) {
+                err.log();
+
+                return view! {};
+            }
+
             series
         };
 
@@ -40,9 +45,9 @@ pub fn CandleStickSeries(
                 let chart = chart.clone();
 
                 let _ = Effect::new(move || {
-                    options
-                        .with(|options| chart.update_series_options(id.clone(), options))
-                        .unwrap();
+                    if let Err(err) = options.with(|options| chart.update_series_options(id.clone(), options)) {
+                        err.log();
+                    }
                 });
             }
 
@@ -51,7 +56,9 @@ pub fn CandleStickSeries(
                 let chart = chart.clone();
 
                 move || {
-                    data.with(|data| chart.update_data(id.clone(), data)).unwrap();
+                    if let Err(err) = data.with(|data| chart.update_data(id.clone(), data)) {
+                        err.log();
+                    }
                 }
             });
 
@@ -60,7 +67,9 @@ pub fn CandleStickSeries(
                 let chart = chart.clone();
 
                 move || {
-                    markers.with(|markers| chart.set_markers(id.clone(), markers)).unwrap();
+                    if let Err(err) = markers.with(|markers| chart.set_markers(id.clone(), markers)) {
+                        err.log();
+                    }
                 }
             });
         }


### PR DESCRIPTION
C'est une première ébauche.

Sans doute qu'il faudrait traiter les erreurs autrement, faire des `throw` ou notifier l'erreur par des callbacks passés en propriété du composant.